### PR TITLE
fix: inversion in the Azure Pipelines agents comparison table

### DIFF
--- a/docs/markdown/02-project/03-build-deploy/01-pipelines.md
+++ b/docs/markdown/02-project/03-build-deploy/01-pipelines.md
@@ -47,8 +47,8 @@ Hosting:
 | Microsoft                                              | Self-hosted                           |
 |--------------------------------------------------------|---------------------------------------|
 | - Environnement "clean" à chaque execution (plus lent) | - Build incrémentielles (plus rapide) |
-| - 0 maintenance                                        | - Illimité                            |
-| - Minutes gratuites                                    | - Maintenance                         |
+| - 0 maintenance                                        | - Maintenance                         |
+| - Minutes gratuites                                    | - Illimité                            |
 
 
 Compatibilité
@@ -79,6 +79,7 @@ Avantages
     - lock exclusif
     - autres: azure function; api REST, ...
 
+##--##
 
 ## Service Connections
 - Azure


### PR DESCRIPTION
There is a small inversion between two rows of the Azure Pipelines agents comparison table.
There is also a fix for the "Service Connections" section that was outside the slide.